### PR TITLE
Fix horizontal scroll cutting off first element in workflow integration map

### DIFF
--- a/src/workflow-integration-map.html
+++ b/src/workflow-integration-map.html
@@ -35,7 +35,7 @@
         .workflow-map {
             display: flex;
             gap: 10px;
-            justify-content: center;
+            justify-content: flex-start;
             align-items: flex-start;
             padding: 20px;
             overflow-x: auto;


### PR DESCRIPTION
## Summary
- Fixed horizontal scroll issue in workflow-integration-map.html where the first stage element was being cut off on narrow screens
- Changed `justify-content: center` to `justify-content: flex-start` in `.workflow-map` CSS

## Test plan
- [x] Open workflow-integration-map.html in browser
- [x] Resize window to narrow width to trigger horizontal scroll
- [x] Verify first element (Plan stage) is fully visible when scrolling left
- [x] Verify all stages remain properly aligned

🤖 Generated with [Claude Code](https://claude.ai/code)